### PR TITLE
Free Camera: Fix two de-sync issues. Fixes #162.

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinClientPlayerEntity.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinClientPlayerEntity.java
@@ -19,6 +19,7 @@ import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.util.Hand;
 import fi.dy.masa.tweakeroo.config.Configs;
 import fi.dy.masa.tweakeroo.config.FeatureToggle;
+import fi.dy.masa.tweakeroo.util.CameraEntity;
 import fi.dy.masa.tweakeroo.util.CameraUtils;
 import fi.dy.masa.tweakeroo.util.DummyMovementInput;
 
@@ -122,7 +123,7 @@ public abstract class MixinClientPlayerEntity extends AbstractClientPlayerEntity
     @Inject(method = "isCamera", at = @At("HEAD"), cancellable = true)
     private void allowPlayerMovementInFreeCameraMode(CallbackInfoReturnable<Boolean> cir)
     {
-        if (FeatureToggle.TWEAK_FREE_CAMERA.getBooleanValue() && Configs.Generic.FREE_CAMERA_PLAYER_MOVEMENT.getBooleanValue())
+        if (FeatureToggle.TWEAK_FREE_CAMERA.getBooleanValue() && CameraEntity.originalCameraWasPlayer())
         {
             cir.setReturnValue(true);
         }

--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinEntity.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinEntity.java
@@ -43,11 +43,7 @@ public abstract class MixinEntity
     {
         if ((Object) this instanceof net.minecraft.client.network.ClientPlayerEntity)
         {
-            if (CameraUtils.shouldPreventPlayerMovement())
-            {
-                ci.cancel();
-            }
-            else if (FeatureToggle.TWEAK_SNAP_AIM.getBooleanValue())
+            if (FeatureToggle.TWEAK_SNAP_AIM.getBooleanValue())
             {
                 double speed = motion.lengthSquared();
 
@@ -73,9 +69,6 @@ public abstract class MixinEntity
         {
             if (CameraUtils.shouldPreventPlayerMovement())
             {
-                this.yaw = this.prevYaw;
-                this.pitch = this.prevPitch;
-
                 CameraUtils.updateCameraRotations((float) yawChange, (float) pitchChange);
                 ci.cancel();
 


### PR DESCRIPTION
- Fix a client-server position de-sync caused by not sending position updates
  in Free Camera mode due to the isCamera() check
- Fix the camera getting de-synced if the player dies in Free Camera mode
  (the old client player entity was restored as the camera entity)